### PR TITLE
De-emphasize the date in the post title

### DIFF
--- a/themes/cfgmgmtcamp/assets/css/stylesheet.css
+++ b/themes/cfgmgmtcamp/assets/css/stylesheet.css
@@ -183,6 +183,12 @@ section div h3 {
 	margin-bottom: 5px;
 	border-bottom: 10px #ff00ff;
 }
+section div .post-date {
+	font-size: 12px;
+	color: #000000;
+        padding: 0px;
+        margin: -12px 0px 0px 0px;
+}
 section div ul li {
 	margin: 5px 0 5px 0;
 }

--- a/themes/cfgmgmtcamp/layouts/index.html
+++ b/themes/cfgmgmtcamp/layouts/index.html
@@ -18,7 +18,8 @@
 	<section id="about">
 		<div class="inner">
 		{{ range first 5 (where .Data.Pages "Type" "posts") }}
-			<h1>{{ .Title }} - {{ .Date.Format "2th January 2006" }}</h1>
+			<h1>{{ .Title }}</h1>
+                        <div class="post-date">{{ .Date.Format "2 January 2006" }}</div>
 			{{ .Content }}
 		{{ end  }}
 		</div>


### PR DESCRIPTION
Knowing the date is important, having it the same size as the title of the post is unnecessary.

This also changes the format of the dates slightly.

Signed-off-by: Nathen Harvey <nathen.harvey@gmail.com>