### PR TITLE
Shorten Foreman Community Update, add another Foreman talk in to fill schedule

### DIFF
--- a/content/schedule/monday/foremanclients.md
+++ b/content/schedule/monday/foremanclients.md
@@ -1,0 +1,16 @@
+---
+title: "Clients, TheForeman, and you. Reusing your server lifecycle management for client machines"
+speaker: alexanderolofsson
+eventtype: talk
+room: 3.foreman
+start: 14:30
+end: 14:55
+date: 2018-12-29
+draft: false
+---
+
+Clients and servers nowadays can be treated much more alike than many people
+might think, so in this talk I'll be going over how to extend your server
+management tooling to also handle clients - though perhaps not quite as well as
+the servers it's designed for.
+

--- a/content/schedule/monday/foremanrel.md
+++ b/content/schedule/monday/foremanrel.md
@@ -1,16 +1,18 @@
 ---
-title: "The Foreman Release Process and Roadmap"
+title: "The Foreman Community Update"
 speaker: tomerbrisker
 eventtype: talk
 room: 3.foreman
 start: 14:00
-end: 14:55
+end: 14:25
 date: 2018-12-29
 draft: false
 ---
 
-The first part of the talk will be a short description of the release process of Foreman,
-as well as some changes that have been made to it over the past year to ensure higher quality releases.  
-The second part will be an open discussion of the roadmap for the upcoming releases.  
-This is your chance to influence the future direction of the Foreman project - come and say your opinions!  
+The first half of the talk with be the yearly Community Update given by Greg,
+summarizing the work done in the past year, notable highlights, and potential
+issues.
 
+The second part will be a look to the year ahead with Tomer, as well as a more
+detailed look at the changes so far in the release process, and what that means
+for our builds in terms of frequency and stability.

--- a/content/speaker/alexanderolofsson.md
+++ b/content/speaker/alexanderolofsson.md
@@ -1,0 +1,10 @@
+---
+title: "Alexander Olofsson"
+twitter: ananace13
+date: 2019-01-20
+draft: false
+---
+
+Alexander Olofsson is a programmer and sysadmin employed at Linköping
+University, working to automate and modernize infrastructure as well as tooling
+to allow for quicker development and faster deliveries.

--- a/content/speaker/tomerbrisker.md
+++ b/content/speaker/tomerbrisker.md
@@ -1,13 +1,19 @@
 ---
-title: "Tomer Brisker"
+title: "Tomer Brisker & Greg Sutcliffe"
 image: https://cfp.cfgmgmtcamp.be/uploads/bd98d11b117976540f3f05e1ade124ee0d499eeed74ddb2651.jpeg
 twitter: tbrisker_pro
 date: 2019-01-03
 draft: false
 ---
 
+Tomer: 
+
 Foreman core maintainer and release manager.  
 Senior Software Engineer at Red Hat Israel.  
 Long time Linux geek and Open Source advocate.  
 Board member of the Israeli FOSS non-profit, Hamakor.  
 
+Greg:
+
+Foreman Community Manager, data scientist, tinkerer, and FOSS evangelist.
+Don't mention bad statistics in his presence unless you want a lecture :)


### PR DESCRIPTION
## Types of content changes

- [x] Talk Abstract
- [x] Speaker Biography
- [x] Schedule timing
- [ ] Spelling mistake

## Scheduling changes

If you are requesting a change of schedule, please check the following list :

- [x] Is your new timing aligned with the timeslots
- [x] Have you moved another talk also
- [x] Did you ask that the other speaker that they have no issues with being rescheduled

# Notes

The Foreman Community Update does not need 50 min. Looking at what we reserved on the track, and who can speak, the obvious choice was Alexander's talk. I've confirmed that @ananace can attend, so this should be good to go.

Since the system doesn't seem to like dual speakers, I've also added my details to Tomer's page. We only have this one shared talk, so sharing it will suffice. I've checked this is OK with @tbrisker.