### PR TITLE
QR code for ics is nice. Actual ics link is nicer!

### DIFF
--- a/themes/cfgmgmtcamp/layouts/shortcodes/icslink.md
+++ b/themes/cfgmgmtcamp/layouts/shortcodes/icslink.md
@@ -1,6 +1,6 @@
 {{ if (fileExists "static/schedule/ical.svg") }}
 	<div class="overview-qr">
-		This is the qrcode for the ical ics file :
-		<img src="/schedule/ical.svg">
+		This is the qrcode for the <a href="/schedule/schedule.ics">ical ics file:
+		<img src="/schedule/ical.svg"></a>
 	</div>
 {{ end }}


### PR DESCRIPTION
For both mobile and full-OS devices, providing an ICS link is actually much more useful than providing a QR code that points to the ICS.